### PR TITLE
fixing latest version for linux

### DIFF
--- a/filter_plugins/sort_versions.py
+++ b/filter_plugins/sort_versions.py
@@ -1,0 +1,25 @@
+"""Sort complex versions"""
+
+from distutils.version import LooseVersion
+
+
+def filter_sort_versions(value):
+    """
+        Ansible entrypoint function
+    """
+    return sorted(value, key=LooseVersion)
+
+
+class FilterModule(object):
+    """
+        Sort complex versions like 0.10.2, 0.1.1, 0.10.12
+    """
+    filter_sort = {
+        'sort_versions': filter_sort_versions,
+    }
+
+    def filters(self):
+        """
+            Return the sorted values
+        """
+        return self.filter_sort

--- a/tasks/setup-Linux.yml
+++ b/tasks/setup-Linux.yml
@@ -9,22 +9,8 @@
   when: vagrant_version == 'latest'
 
 - name: Linux | Finds the latest version of Vagrant when latest var is define
-  shell:
-    cmd: |
-      set -${-//[sc]/}eu${DEBUG+xv}o pipefail
-      IFS=" " read -r -a arrayzz
-      IFS=$'\n' sorted=($( sort -t '.' -k1,1nr -k2,2nr -k3,3nr <<<"${arrayzz[*]}" ))
-      printf '%s' "${sorted[0]}"
-  args:
-    stdin: '{{ (vagrant_index.content | from_json).versions | list | join(" ") }}'
-    executable: /bin/bash
-  register: shell_output
-  changed_when: False
-  when: vagrant_version == 'latest'
-
-- name: Linux | Use the specified Vagrant version from the previous command's register
   set_fact:
-    vagrant_version_to_install: '{{ shell_output.stdout }}'
+    vagrant_version_to_install: "{{ (vagrant_index.content | from_json).versions | list | sort_versions | last }}"
   when: vagrant_version == 'latest'
 
 - name: Linux | Use the specified Vagrant version when latest var is not define

--- a/tasks/setup-Linux.yml
+++ b/tasks/setup-Linux.yml
@@ -9,9 +9,22 @@
   when: vagrant_version == 'latest'
 
 - name: Linux | Finds the latest version of Vagrant when latest var is define
+  shell:
+    cmd: |
+      set -${-//[sc]/}eu${DEBUG+xv}o pipefail
+      IFS=" " read -r -a arrayzz
+      IFS=$'\n' sorted=($( sort -t '.' -k1,1nr -k2,2nr -k3,3nr <<<"${arrayzz[*]}" ))
+      printf '%s' "${sorted[0]}"
+  args:
+    stdin: '{{ (vagrant_index.content | from_json).versions | list | join(" ") }}'
+    executable: /bin/bash
+  register: shell_output
+  changed_when: False
+  when: vagrant_version == 'latest'
+
+- name: Linux | Use the specified Vagrant version from the previous command's register
   set_fact:
-    vagrant_version_to_install: "{{ item }}"
-  with_items: "{{ (vagrant_index.content | from_json).versions | list | sort | last }}"
+    vagrant_version_to_install: '{{ shell_output.stdout }}'
   when: vagrant_version == 'latest'
 
 - name: Linux | Use the specified Vagrant version when latest var is not define


### PR DESCRIPTION
Hey @diodonfrost, I just wanted to submit this code (probably need to adapt it to whatever format you want), because I noticed a flaw with the sorting mechanism on Linux. We are currently on 2.2.10 release of vagrant, and you script was grabbing 2.2.9. So, it is a bit hacky, but I think it is giving the best results possible. I tried to solve this a more "_ansible_" way, but I couldn't figure out a solution to handle it properly.

here is a quick example of why/how it doesn't work

[![asciicast](https://asciinema.org/a/frdqp5ijiJeJJeKc5u4UaDITm.svg)](https://asciinema.org/a/frdqp5ijiJeJJeKc5u4UaDITm)

the `set` command comes from this (my blog): https://blog.elreydetoda.site/cool-shell-tricks/#bashscriptingmodifiedscripthardening and helps prevent thing from being undefined and more explanation in my blog post.

this assigns everything from stdin to an array value, and I got it from here: https://github.com/koalaman/shellcheck/wiki/SC2207
`IFS=" " read -r -a arrayzz`

then the next line reads in that previously assigned array and sorts the values in the array with the latest value being at the top. So, then at the end you print out the first value in the array. which should be the latest release. got it from [here](https://stackoverflow.com/questions/7442417/how-to-sort-an-array-in-bash#answer-11789688), and modified it a bit to suit my sorting needs. Better explained [here](https://explainshell.com/explain?cmd=sort+-t+%27.%27+-k1%2C1nr+-k2%2C2nr+-k3%2C3nr+%3C%3C%3C%22%24%7Barrayzz%5B*%5D%7D%22)

```
IFS=$'\n' sorted=($( sort -t '.' -k1,1nr -k2,2nr -k3,3nr <<<"${arrayzz[*]}" ))
```

then you just print out that version so it gets put in the register
